### PR TITLE
Enable C++14 flag for ROS needed for PointCloudLibrary.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,7 @@ add_definitions(-DDEBUG_LEVEL=0)
 #========================
 find_package(roscpp 1.12 QUIET)
 if(roscpp_FOUND)
+  set(CMAKE_CXX_STANDARD 14)
   message(=============================================================)
   message("-- ROS Found, Ros Support is turned On!")
   message(=============================================================)


### PR DESCRIPTION
I was attempting to follow the install instructions in the README, using Ubuntu 20.04 and ROS Noetic. The build failed with both cmake and catkin_make. It appears that PointCloudLibrary requires C++14, but C++11 is set by default. I have set the flag for ROS1 following the example from ROS2, and the build succeds.