### PR TITLE
Add time_offset support

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -21,6 +21,7 @@ lidar:
       end_angle: 360               #End angle of point cloud 
       min_distance: 0.2            #Minimum distance of point cloud
       max_distance: 200            #Maximum distance of point cloud
+      time_offset: 0.0             #Time offset of cloud and packets
       use_lidar_clock: false       #True--Use the lidar clock as the message timestamp
                                    #False-- Use the system clock as the timestamp  
     ros:

--- a/src/adapter/driver_adapter.hpp
+++ b/src/adapter/driver_adapter.hpp
@@ -96,6 +96,7 @@ inline void DriverAdapter::init(const YAML::Node& config)
   yamlRead<bool>(driver_config, "wait_for_difop", driver_param.wait_for_difop, true);
   yamlRead<bool>(driver_config, "saved_by_rows", driver_param.saved_by_rows, false);
   yamlRead<bool>(driver_config, "use_lidar_clock", driver_param.decoder_param.use_lidar_clock, false);
+  yamlRead<float>(driver_config, "time_offset", driver_param.decoder_param.time_offset, 0.0);
   yamlRead<float>(driver_config, "min_distance", driver_param.decoder_param.min_distance, 0.2);
   yamlRead<float>(driver_config, "max_distance", driver_param.decoder_param.max_distance, 200);
   yamlRead<float>(driver_config, "start_angle", driver_param.decoder_param.start_angle, 0);

--- a/src/manager/adapter_manager.cpp
+++ b/src/manager/adapter_manager.cpp
@@ -75,6 +75,7 @@ void AdapterManager::init(const YAML::Node& config)
         RS_INFO << "Receive Packets From : Online LiDAR" << RS_REND;
         RS_INFO << "Msop Port: " << lidar_config[i]["driver"]["msop_port"].as<uint16_t>() << RS_REND;
         RS_INFO << "Difop Port: " << lidar_config[i]["driver"]["difop_port"].as<uint16_t>() << RS_REND;
+        RS_INFO << "Time Offset: " << lidar_config[i]["driver"]["time_offset"].as<std::string>() << RS_REND;
         RS_INFO << "------------------------------------------------------" << RS_REND;
         point_cloud_thread_flag_ = true;
         lidar_config[i]["msg_source"] = (int)MsgSource::MSG_FROM_LIDAR;
@@ -111,6 +112,7 @@ void AdapterManager::init(const YAML::Node& config)
         RS_INFO << "Receive Packets From : Pcap" << RS_REND;
         RS_INFO << "Msop Port: " << lidar_config[i]["driver"]["msop_port"].as<uint16_t>() << RS_REND;
         RS_INFO << "Difop Port: " << lidar_config[i]["driver"]["difop_port"].as<uint16_t>() << RS_REND;
+        RS_INFO << "Time Offset: " << lidar_config[i]["driver"]["time_offset"].as<std::string>() << RS_REND;
         RS_INFO << "------------------------------------------------------" << RS_REND;
         point_cloud_thread_flag_ = true;
         lidar_config[i]["msg_source"] = (int)MsgSource::MSG_FROM_PCAP;


### PR DESCRIPTION
Add time_offset capability to the interface for finetuning timestamps.

Quick implementation only tested on BPearl.