### PR TITLE
Adding ros param to use different config files

### DIFF
--- a/node/rslidar_sdk_node.cpp
+++ b/node/rslidar_sdk_node.cpp
@@ -54,18 +54,6 @@ int main(int argc, char** argv)
   RS_TITLE << "**********                                    **********" << RS_REND;
   RS_TITLE << "********************************************************" << RS_REND;
 
-  std::shared_ptr<AdapterManager> demo_ptr = std::make_shared<AdapterManager>();
-  YAML::Node config;
-  try
-  {
-    config = YAML::LoadFile((std::string)PROJECT_PATH + "/config/config.yaml");
-  }
-  catch (...)
-  {
-    RS_ERROR << "Config file format wrong! Please check the format(e.g. indentation) " << RS_REND;
-    return -1;
-  }
-
 #ifdef ROS_FOUND  ///< if ROS is found, call the ros::init function
   ros::init(argc, argv, "rslidar_sdk_node", ros::init_options::NoSigintHandler);
 #endif
@@ -73,6 +61,26 @@ int main(int argc, char** argv)
 #ifdef ROS2_FOUND  ///< if ROS2 is found, call the rclcpp::init function
   rclcpp::init(argc, argv);
 #endif
+
+
+  std::string config_file = (std::string)PROJECT_PATH + "/config/config.yaml";
+
+#ifdef ROS_FOUND  ///< if ROS is found, call 
+  ros::NodeHandle nh("~");
+  nh.param("rslidar_config_file", config_file, config_file);
+#endif
+
+  std::shared_ptr<AdapterManager> demo_ptr = std::make_shared<AdapterManager>();
+  YAML::Node config;
+  try
+  {
+    config = YAML::LoadFile(config_file);
+  }
+  catch (...)
+  {
+    RS_ERROR << "Config file format wrong! Please check the format(e.g. indentation) " << RS_REND;
+    return -1;
+  }
 
   demo_ptr->init(config);
   demo_ptr->start();


### PR DESCRIPTION
Hi,
the current version of the driver works with a fixed config file located in config/config.yaml inside the project folder.

This is quite inconvenient if we want to use the same driver with different sensors setups with configuration files located on other folders.

This pull request applies a modification to be able to set the config file as a ROS parameter.

The modication works with ROS (not ROS2)