### PR TITLE
Add ROS1 nodelet

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ project(rslidar_sdk)
 #=======================================
 # Compile setup (ORIGINAL, CATKIN, COLCON)
 #=======================================
-set(COMPILE_METHOD COLCON)
+set(COMPILE_METHOD COLCON CACHE STRING "Compilation method")
 
 #=======================================
 # Custom Point Type (XYZI, XYZIRT)
@@ -89,14 +89,20 @@ link_directories(${PCL_LIBRARY_DIRS})
 add_definitions(${PCL_DEFINITIONS})
 #Catkin#
 if(${COMPILE_METHOD} STREQUAL "CATKIN")
+  set(PROJECT_CATKIN_DEPS
+      sensor_msgs
+      nodelet
+      pluginlib
+  )
   find_package(catkin REQUIRED COMPONENTS
-          roscpp
-          sensor_msgs
-          )
+               roscpp
+               ${PROJECT_CATKIN_DEPS}
+               )
 
   catkin_package(
-          CATKIN_DEPENDS sensor_msgs
+    CATKIN_DEPENDS ${PROJECT_CATKIN_DEPS}
   )
+
 endif(${COMPILE_METHOD} STREQUAL "CATKIN")
 #Include directory#
 include_directories(${PROJECT_SOURCE_DIR}/src)
@@ -122,14 +128,28 @@ message(=============================================================)
 #========================
 #Protobuf#
 if(NOT PROTOC MATCHES "NOTFOUND" AND Protobuf_FOUND)
+  set(PROTOBUF_SOURCES
+      ${PROTO_FILE_PATH}/packet.pb.cc
+      ${PROTO_FILE_PATH}/scan.pb.cc
+      ${PROTO_FILE_PATH}/point_cloud.pb.cc
+      )
   add_executable(rslidar_sdk_node
               node/rslidar_sdk_node.cpp
               src/manager/adapter_manager.cpp
-              ${PROTO_FILE_PATH}/packet.pb.cc
-              ${PROTO_FILE_PATH}/scan.pb.cc
-              ${PROTO_FILE_PATH}/point_cloud.pb.cc
+              ${PROTOBUF_SOURCES}
               )
   target_link_libraries(rslidar_sdk_node
+                      ${PCL_LIBRARIES}
+                      ${YAML_CPP_LIBRARIES}
+                      ${PROTOBUF_LIBRARY}
+                      ${rs_driver_LIBRARIES}
+                      )
+  add_library(rslidar_sdk_nodelet
+              node/rslidar_sdk_nodelet.cpp
+              src/manager/adapter_manager.cpp
+              ${PROTOBUF_SOURCES}
+              )
+  target_link_libraries(rslidar_sdk_nodelet
                       ${PCL_LIBRARIES}
                       ${YAML_CPP_LIBRARIES}
                       ${PROTOBUF_LIBRARY}
@@ -145,10 +165,22 @@ else(NOT PROTOC MATCHES "NOTFOUND" AND Protobuf_FOUND)
                       ${YAML_CPP_LIBRARIES}
                       ${rs_driver_LIBRARIES}
                       )
+
+  add_library(rslidar_sdk_nodelet
+              node/rslidar_sdk_nodelet.cpp
+              src/manager/adapter_manager.cpp
+              )
+  target_link_libraries(rslidar_sdk_nodelet
+                      ${PCL_LIBRARIES}
+                      ${YAML_CPP_LIBRARIES}
+                      ${rs_driver_LIBRARIES}
+                      )
+
 endif(NOT PROTOC MATCHES "NOTFOUND" AND Protobuf_FOUND)
 #Ros#
 if(roscpp_FOUND)
   target_link_libraries(rslidar_sdk_node ${roscpp_LIBRARIES})
+  target_link_libraries(rslidar_sdk_nodelet ${roscpp_LIBRARIES})
 endif(roscpp_FOUND)
 #Ros2#
 if(rclcpp_FOUND AND ${COMPILE_METHOD} STREQUAL "COLCON")

--- a/launch/start_nodelet_standalone.launch
+++ b/launch/start_nodelet_standalone.launch
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<launch>
+    <arg name="manager" default="rslidar_nodelet_manager" />
+    <arg name="config_file" default="config/config.yaml" />
+    <node pkg="nodelet" type="nodelet" name="$(arg manager)" args="manager" />
+    <node pkg="nodelet" type="nodelet" name="$(arg manager)_cloud"
+          args="load robosense_lidar/CloudNodelet $(arg manager)" output="screen">
+        <param name="rslidar_config_file" value="$(find rslidar_sdk)/$(arg config_file)" />
+    </node>
+    <node pkg="rviz" name="rviz" type="rviz" args="-d $(find rslidar_sdk)/rviz/rviz.rviz" />
+</launch>

--- a/node/rslidar_sdk_nodelet.cpp
+++ b/node/rslidar_sdk_nodelet.cpp
@@ -1,0 +1,78 @@
+/*********************************************************************************************************************
+Copyright (c) 2020 RoboSense
+All rights reserved
+
+By downloading, copying, installing or using the software you agree to this license. If you do not agree to this
+license, do not download, install, copy or use the software.
+
+License Agreement
+For RoboSense LiDAR SDK Library
+(3-clause BSD License)
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following
+disclaimer in the documentation and/or other materials provided with the distribution.
+
+3. Neither the names of the RoboSense, nor Suteng Innovation Technology, nor the names of other contributors may be used
+to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*********************************************************************************************************************/
+
+#ifdef ROS_FOUND
+
+#include <ros/ros.h>
+#include <pluginlib/class_list_macros.h>
+#include <nodelet/nodelet.h>
+
+#include "manager/adapter_manager.h"
+
+namespace robosense
+{
+namespace lidar
+{
+class CloudNodelet : public nodelet::Nodelet
+{
+public:
+    CloudNodelet(){}
+    ~CloudNodelet(){}
+private:
+    virtual void onInit();
+    std::shared_ptr<AdapterManager> adapter_ptr_;
+};
+
+void CloudNodelet::onInit()
+{
+    std::string config_file = (std::string)PROJECT_PATH + "/config/config.yaml";
+    getPrivateNodeHandle().param("rslidar_config_file", config_file, config_file);
+    YAML::Node config;
+    try
+    {
+        config = YAML::LoadFile(config_file);
+    }
+    catch (...)
+    {
+        RS_ERROR << "Config file format wrong! Please check the format(e.g. indentation) " << RS_REND;
+        return;
+    }
+    adapter_ptr_.reset(new AdapterManager());
+    adapter_ptr_->init(config);
+    adapter_ptr_->start();
+}
+}   // namespace lidar
+}   // namespace robosense
+
+PLUGINLIB_EXPORT_CLASS(robosense::lidar::CloudNodelet, nodelet::Nodelet)
+
+#endif

--- a/nodelets.xml
+++ b/nodelets.xml
@@ -1,0 +1,9 @@
+<library path="lib/librslidar_sdk_nodelet">
+  <class name="robosense_lidar/CloudNodelet"
+         type="robosense::lidar::CloudNodelet"
+         base_class_type="nodelet::Nodelet">
+    <description>
+      Aggregates points from multiple packets, publishing PointCloud2.
+    </description>
+  </class>
+</library>

--- a/package_ros1.xml
+++ b/package_ros1.xml
@@ -9,7 +9,13 @@
 
   <build_depend>roscpp</build_depend>
   <build_depend>sensor_msgs</build_depend>
-
+  <build_depend>nodelet</build_depend>
+  <build_depend>pluginlib</build_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>sensor_msgs</run_depend>
+  <run_depend>nodelet</run_depend>
+  <run_depend>pluginlib</run_depend>
+  <export>
+    <nodelet plugin="${prefix}/nodelets.xml"/>
+  </export>
 </package>


### PR DESCRIPTION
### Proposed changes in this PR
- Set `COMPILE_METHOD` in CMakeLists to accept command line argument (e.g `cmake .. -DCOMPILE_METHOD=ORIGINAL`, so that it is no longer necessary to modify CMakeLists.txt file)
- Add a ROS1 nodelet and launch file, getting the location of the configuration file in the same way as #39 