### PR TITLE
Loading config path from ROS2 parameter

### DIFF
--- a/node/rslidar_sdk_node.cpp
+++ b/node/rslidar_sdk_node.cpp
@@ -66,9 +66,8 @@ int main(int argc, char** argv)
 
   RS_TITLE << "********************************************************" << RS_REND;
   RS_TITLE << "**********                                    **********" << RS_REND;
-  RS_TITLE << "**********    RSLidar_SDK Version: v" << RSLIDAR_VERSION_MAJOR 
-    << "." << RSLIDAR_VERSION_MINOR 
-    << "." << RSLIDAR_VERSION_PATCH << "     **********" << RS_REND;
+  RS_TITLE << "**********    RSLidar_SDK Version: v" << RSLIDAR_VERSION_MAJOR << "." << RSLIDAR_VERSION_MINOR << "."
+           << RSLIDAR_VERSION_PATCH << "     **********" << RS_REND;
   RS_TITLE << "**********                                    **********" << RS_REND;
   RS_TITLE << "********************************************************" << RS_REND;
 
@@ -81,17 +80,23 @@ int main(int argc, char** argv)
   std::string config_path;
 
 #ifdef RUN_IN_ROS_WORKSPACE
-   config_path = ros::package::getPath("rslidar_sdk");
+  config_path = ros::package::getPath("rslidar_sdk");
 #else
-   config_path = (std::string)PROJECT_PATH;
+  config_path = (std::string)PROJECT_PATH;
 #endif
 
-   config_path += "/config/config.yaml";
+  config_path += "/config/config.yaml";
 
 #ifdef ROS_FOUND
   ros::NodeHandle priv_hh("~");
   std::string path;
   priv_hh.param("config_path", path, std::string(""));
+#elif ROS2_FOUND
+  std::shared_ptr<rclcpp::Node> nd = rclcpp::Node::make_shared("param_handle");
+  std::string path = nd->declare_parameter<std::string>("config_path", "");
+#endif
+
+#if defined(ROS_FOUND) || defined(ROS2_FOUND)
   if (!path.empty())
   {
     config_path = path;
@@ -105,8 +110,7 @@ int main(int argc, char** argv)
   }
   catch (...)
   {
-    RS_ERROR << "The format of config file " << config_path 
-      << " is wrong. Please check (e.g. indentation)." << RS_REND;
+    RS_ERROR << "The format of config file " << config_path << " is wrong. Please check (e.g. indentation)." << RS_REND;
     return -1;
   }
 

--- a/node/rslidar_sdk_node.cpp
+++ b/node/rslidar_sdk_node.cpp
@@ -107,6 +107,10 @@ int main(int argc, char** argv)
   try
   {
     config = YAML::LoadFile(config_path);
+    RS_INFO << "--------------------------------------------------------" << RS_REND;
+    RS_INFO << "Config loaded from PATH:" << RS_REND;
+    RS_INFO << config_path << RS_REND;
+    RS_INFO << "--------------------------------------------------------" << RS_REND;
   }
   catch (...)
   {


### PR DESCRIPTION
Previously, you added a feature to load config file path from ROS1 parameter, but you omitted ROS2. This feature is necessary to properly load the configuration file, which is placed outside the package location in ROS2. 
I have also added printing out information, from what path the configuration file is currently loaded.
I created pull request with my solution for that.