### PR TITLE
Changed intensity from float to uint8

### DIFF
--- a/doc/howto/05_how_to_change_point_type.md
+++ b/doc/howto/05_how_to_change_point_type.md
@@ -74,7 +74,7 @@ rslidar_sdk transforms point cloud of `PointXYZIRT` to ROS message of `PointClou
  addPointField(ros_msg, "x", 1, sensor_msgs::PointField::FLOAT32, offset);
  addPointField(ros_msg, "y", 1, sensor_msgs::PointField::FLOAT32, offset);
  addPointField(ros_msg, "z", 1, sensor_msgs::PointField::FLOAT32, offset);
- addPointField(ros_msg, "intensity", 1, sensor_msgs::PointField::FLOAT32, offset);
+ addPointField(ros_msg, "intensity", 1, sensor_msgs::PointField::UINT8, offset);
 #ifdef POINT_TYPE_XYZIRT
  sensor_msgs::PointCloud2Iterator<uint16_t> iter_ring_(ros_msg, "ring");
  sensor_msgs::PointCloud2Iterator<double> iter_timestamp_(ros_msg, "timestamp");

--- a/doc/howto/05_how_to_change_point_type_CN.md
+++ b/doc/howto/05_how_to_change_point_type_CN.md
@@ -73,7 +73,7 @@ rslidar_sdk将基于`PointXYZIRT`的点云，转换为ROS的PointCloud2消息，
  addPointField(ros_msg, "x", 1, sensor_msgs::PointField::FLOAT32, offset);
  addPointField(ros_msg, "y", 1, sensor_msgs::PointField::FLOAT32, offset);
  addPointField(ros_msg, "z", 1, sensor_msgs::PointField::FLOAT32, offset);
- addPointField(ros_msg, "intensity", 1, sensor_msgs::PointField::FLOAT32, offset);
+ addPointField(ros_msg, "intensity", 1, sensor_msgs::PointField::UINT8, offset);
 #ifdef POINT_TYPE_XYZIRT
  sensor_msgs::PointCloud2Iterator<uint16_t> iter_ring_(ros_msg, "ring");
  sensor_msgs::PointCloud2Iterator<double> iter_timestamp_(ros_msg, "timestamp");

--- a/src/source/source_pointcloud_ros.hpp
+++ b/src/source/source_pointcloud_ros.hpp
@@ -69,7 +69,7 @@ inline sensor_msgs::PointCloud2 toRosMsg(const LidarPointCloudMsg& rs_msg, const
   offset = addPointField(ros_msg, "x", 1, sensor_msgs::PointField::FLOAT32, offset);
   offset = addPointField(ros_msg, "y", 1, sensor_msgs::PointField::FLOAT32, offset);
   offset = addPointField(ros_msg, "z", 1, sensor_msgs::PointField::FLOAT32, offset);
-  offset = addPointField(ros_msg, "intensity", 1, sensor_msgs::PointField::FLOAT32, offset);
+  offset = addPointField(ros_msg, "intensity", 1, sensor_msgs::PointField::UINT8, offset);
 #ifdef POINT_TYPE_XYZIRT
   offset = addPointField(ros_msg, "ring", 1, sensor_msgs::PointField::UINT16, offset);
   offset = addPointField(ros_msg, "timestamp", 1, sensor_msgs::PointField::FLOAT64, offset);
@@ -87,7 +87,7 @@ inline sensor_msgs::PointCloud2 toRosMsg(const LidarPointCloudMsg& rs_msg, const
   sensor_msgs::PointCloud2Iterator<float> iter_x_(ros_msg, "x");
   sensor_msgs::PointCloud2Iterator<float> iter_y_(ros_msg, "y");
   sensor_msgs::PointCloud2Iterator<float> iter_z_(ros_msg, "z");
-  sensor_msgs::PointCloud2Iterator<float> iter_intensity_(ros_msg, "intensity");
+  sensor_msgs::PointCloud2Iterator<uint8_t> iter_intensity_(ros_msg, "intensity");
 #ifdef POINT_TYPE_XYZIRT
   sensor_msgs::PointCloud2Iterator<uint16_t> iter_ring_(ros_msg, "ring");
   sensor_msgs::PointCloud2Iterator<double> iter_timestamp_(ros_msg, "timestamp");
@@ -236,7 +236,7 @@ inline sensor_msgs::msg::PointCloud2 toRosMsg(const LidarPointCloudMsg& rs_msg, 
   offset = addPointField(ros_msg, "x", 1, sensor_msgs::msg::PointField::FLOAT32, offset);
   offset = addPointField(ros_msg, "y", 1, sensor_msgs::msg::PointField::FLOAT32, offset);
   offset = addPointField(ros_msg, "z", 1, sensor_msgs::msg::PointField::FLOAT32, offset);
-  offset = addPointField(ros_msg, "intensity", 1, sensor_msgs::msg::PointField::FLOAT32, offset);
+  offset = addPointField(ros_msg, "intensity", 1, sensor_msgs::msg::PointField::UINT8, offset);
 #ifdef POINT_TYPE_XYZIRT
   offset = addPointField(ros_msg, "ring", 1, sensor_msgs::msg::PointField::UINT16, offset);
   offset = addPointField(ros_msg, "timestamp", 1, sensor_msgs::msg::PointField::FLOAT64, offset);
@@ -254,7 +254,7 @@ inline sensor_msgs::msg::PointCloud2 toRosMsg(const LidarPointCloudMsg& rs_msg, 
   sensor_msgs::PointCloud2Iterator<float> iter_x_(ros_msg, "x");
   sensor_msgs::PointCloud2Iterator<float> iter_y_(ros_msg, "y");
   sensor_msgs::PointCloud2Iterator<float> iter_z_(ros_msg, "z");
-  sensor_msgs::PointCloud2Iterator<float> iter_intensity_(ros_msg, "intensity");
+  sensor_msgs::PointCloud2Iterator<uint8_t> iter_intensity_(ros_msg, "intensity");
 #ifdef POINT_TYPE_XYZIRT
   sensor_msgs::PointCloud2Iterator<uint16_t> iter_ring_(ros_msg, "ring");
   sensor_msgs::PointCloud2Iterator<double> iter_timestamp_(ros_msg, "timestamp");


### PR DESCRIPTION
I have changed the intensity field in ROS `PointCloud2` because I see no advantage in converting this field from `UINT8` to `FLOAT` type.
The intensity in `LidarPointCloudMsg` is kept as `UINT8` and only when converting to ROS message the intensity is converted to float type. There is no advantage in this conversion, but there are costs of greater message size and additional performance costs of converting floating point to byte for the receiver of this message.