### PR TITLE
Insert ros2 dependencies into package.xml

### DIFF
--- a/package_ros2.xml
+++ b/package_ros2.xml
@@ -14,6 +14,8 @@
   <exec_depend>sensor_msgs</exec_depend>
   <exec_depend>std_msgs</exec_depend>
   <depend>rslidar_msg</depend>
+  <depend>yaml-cpp</depend>
+  <depend>libpcap</depend>
   <export>
      <build_type>ament_cmake</build_type>
   </export>


### PR DESCRIPTION
Now with `rosdep` install can install these dependencies automatically, instead of running host commands.
