### PR TITLE
Fix version number with tag

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package>
   <name>rslidar_sdk</name>
-  <version>1.5.0</version>
+  <version>1.5.14</version>
   <description>The rslidar_sdk package</description>
   <maintainer email="ron.zheng@robosense.cn">robosense</maintainer>
   <license>BSD</license>

--- a/package_ros1.xml
+++ b/package_ros1.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package>
   <name>rslidar_sdk</name>
-  <version>1.5.0</version>
+  <version>1.5.14</version>
   <description>The rslidar_sdk package</description>
   <maintainer email="ron.zheng@robosense.cn">robosense</maintainer>
   <license>BSD</license>

--- a/package_ros2.xml
+++ b/package_ros2.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>rslidar_sdk</name>
-  <version>1.5.0</version>
+  <version>1.5.14</version>
   <description>The rslidar_sdk package</description>
   <maintainer email="ron.zheng@robosense.cn">robosense</maintainer>
   <license>BSD</license>
@@ -19,6 +19,3 @@
   </export>
   
 </package>
-
-
-


### PR DESCRIPTION
The tags in the repository do not match the versions in the package.xml.
This messes up some tooling which tries to parse the version numbers.