### PR TITLE
feat: enable IMU

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,17 +45,6 @@ if(${ENABLE_SOURCE_PACKET_LEGACY})
   add_definitions("-DENABLE_SOURCE_PACKET_LEGACY")
 endif(${ENABLE_SOURCE_PACKET_LEGACY})
 
-option(ENABLE_IMU_DATA_PARSE           "Enable imu data parse" OFF)
-if(${ENABLE_IMU_DATA_PARSE})
-
-  message(=============================================================)
-  message("-- Enable imu data parse")
-  message(=============================================================)
-
-  add_definitions("-DENABLE_IMU_DATA_PARSE")
-
-endif(${ENABLE_IMU_DATA_PARSE})
-
 #========================
 # Project details / setup
 #========================

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -7,13 +7,13 @@ common:
   send_point_cloud_ros: true            # true: Send point cloud through ROS or ROS2
 lidar:
   - driver:
-      lidar_type: RSM1             #  LiDAR type - RS16, RS32, RSBP, RSAIRY, RSHELIOS, RSHELIOS_16P, RS128, RS80, RS48, RSP128, RSP80, RSP48, 
+      lidar_type: RSM1             #  LiDAR type - RS16, RS32, RSBP, RSAIRY, RSHELIOS, RSHELIOS_16P, RS128, RS80, RS48, RSP128, RSP80, RSP48,
                                    #               RSM1, RSM1_JUMBO, RSM2, RSM3, RSE1, RSMX.
                                    
       msop_port: 6699              #  Msop port of lidar
       difop_port: 7788             #  Difop port of lidar
       imu_port: 0                  #  IMU port of lidar(only for RSAIRY, RSE1), 0 means no imu.
-                                   #  If you want to use IMU, please first set ENABLE_IMU_DATA_PARSE to ON in CMakeLists.txt 
+                                   #  If you want to use IMU, please first set enable_imu_data:=true when you launch the ros node
       user_layer_bytes: 0          #  Bytes of user layer. thers is no user layer if it is 0         
       tail_layer_bytes: 0          #  Bytes of tail layer. thers is no tail layer if it is 0
 

--- a/launch/elequent_start.py
+++ b/launch/elequent_start.py
@@ -1,21 +1,33 @@
 from launch import LaunchDescription
 from launch_ros.actions import Node
+from launch.actions import DeclareLaunchArgument
+from launch.substitutions import LaunchConfiguration
 from ament_index_python.packages import get_package_share_directory
+
 def generate_launch_description():
-    rviz_config=get_package_share_directory('rslidar_sdk')+'/rviz/rviz2.rviz'
+    rviz_config = get_package_share_directory('rslidar_sdk') + '/rviz/rviz2.rviz'
+    config_file = '' 
+
+    enable_imu_data_arg = DeclareLaunchArgument(
+        'enable_imu_data',
+        default_value='false',
+        description='Enable IMU data parsing'
+    )
+
     return LaunchDescription([
+        enable_imu_data_arg,
         Node(
             package='rslidar_sdk',
-            node_namespace='rslidar_sdk',
-            node_name='rslidar_sdk_node',
             node_executable='rslidar_sdk_node',
-            output='screen'
+            output='screen',
+            parameters=[
+                {'config_path': config_file},
+                {'enable_imu_data': LaunchConfiguration('enable_imu_data')}
+            ]
         ),
         Node(
             package='rviz2',
-            node_namespace='rviz2',
-            node_name='rviz2',
             node_executable='rviz2',
-            arguments=['-d',rviz_config]
+            arguments=['-d', rviz_config]
         )
     ])

--- a/launch/humble_start.py
+++ b/launch/humble_start.py
@@ -4,6 +4,8 @@ import sys
 from getpass import getpass
 from launch import LaunchDescription
 from launch_ros.actions import Node
+from launch.actions import DeclareLaunchArgument
+from launch.substitutions import LaunchConfiguration
 from ament_index_python.packages import get_package_share_directory
 
 def install_cyclone_dds():
@@ -30,9 +32,32 @@ def generate_launch_description():
         print(f"Environment Variable Set: RMW_IMPLEMENTATION={os.environ.get('RMW_IMPLEMENTATION')}")
 
     rviz_config = get_package_share_directory('rslidar_sdk') + '/rviz/rviz2.rviz'
+    config_file = ''  
+
+    # declare enable_imu_data parameter 
+    enable_imu_data_arg = DeclareLaunchArgument(
+        'enable_imu_data',
+        default_value='false',
+        description='Enable IMU data parsing'
+    )
 
     return LaunchDescription([
-        Node(namespace='rslidar_sdk', package='rslidar_sdk', executable='rslidar_sdk_node', output='screen'),
-        Node(namespace='rviz2', package='rviz2', executable='rviz2', arguments=['-d', rviz_config])
+        enable_imu_data_arg,
+        Node(
+            namespace='rslidar_sdk',
+            package='rslidar_sdk',
+            executable='rslidar_sdk_node',
+            output='screen',
+            parameters=[
+                {'config_path': config_file},
+                {'enable_imu_data': LaunchConfiguration('enable_imu_data')}
+            ]
+        ),
+        Node(
+            namespace='rviz2',
+            package='rviz2',
+            executable='rviz2',
+            arguments=['-d', rviz_config]
+        )
     ])
 

--- a/launch/start.launch
+++ b/launch/start.launch
@@ -1,6 +1,9 @@
 <launch>
+  <arg name="enable_imu_data" default="false"/>
+  
   <node pkg="rslidar_sdk" name="rslidar_sdk_node" type="rslidar_sdk_node" output="screen">
     <param name="config_path" value=""/>
+    <param name="enable_imu_data" value="$(arg enable_imu_data)"/>
   </node>
   <!-- rviz -->
   <node pkg="rviz" name="rviz" type="rviz" args="-d $(find rslidar_sdk)/rviz/rviz.rviz" />

--- a/launch/start.py
+++ b/launch/start.py
@@ -1,14 +1,37 @@
 from launch import LaunchDescription
 from launch_ros.actions import Node
+from launch.actions import DeclareLaunchArgument
+from launch.substitutions import LaunchConfiguration
 from ament_index_python.packages import get_package_share_directory
 
 def generate_launch_description():
 
-    rviz_config=get_package_share_directory('rslidar_sdk')+'/rviz/rviz2.rviz'
+    rviz_config = get_package_share_directory('rslidar_sdk') + '/rviz/rviz2.rviz'
+    config_file = ''  # your config file path
 
-    config_file = '' # your config file path
-    
+    # declare enable_imu_data parameter 
+    enable_imu_data_arg = DeclareLaunchArgument(
+        'enable_imu_data',
+        default_value='false',
+        description='Enable IMU data parsing'
+    )
+
     return LaunchDescription([
-        Node(namespace='rslidar_sdk', package='rslidar_sdk', executable='rslidar_sdk_node', output='screen', parameters=[{'config_path': config_file}]),
-        Node(namespace='rviz2', package='rviz2', executable='rviz2', arguments=['-d',rviz_config])
+        enable_imu_data_arg,
+        Node(
+            namespace='rslidar_sdk',
+            package='rslidar_sdk',
+            executable='rslidar_sdk_node',
+            output='screen',
+            parameters=[
+                {'config_path': config_file},
+                {'enable_imu_data': LaunchConfiguration('enable_imu_data')}
+            ]
+        ),
+        Node(
+            namespace='rviz2',
+            package='rviz2',
+            executable='rviz2',
+            arguments=['-d', rviz_config]
+        )
     ])

--- a/node/rslidar_sdk_node.cpp
+++ b/node/rslidar_sdk_node.cpp
@@ -88,13 +88,17 @@ int main(int argc, char** argv)
 
    config_path += "/config/config.yaml";
 
+// read the params from ROS server
 #ifdef ROS_FOUND
   ros::NodeHandle priv_hh("~");
   std::string path;
+  bool enable_imu_data;
   priv_hh.param("config_path", path, std::string(""));
+  priv_hh.getParam("enable_imu_data", enable_imu_data);
 #elif ROS2_FOUND
-  std::shared_ptr<rclcpp::Node> nd = rclcpp::Node::make_shared("param_handle");
+  std::shared_ptr<rclcpp::Node> nd = rclcpp::Node::make_shared("rslidar_sdk_node");
   std::string path = nd->declare_parameter<std::string>("config_path", "");
+  bool enable_imu_data = nd->declare_parameter<bool>("enable_imu_data", false);
 #endif
 
 #if defined(ROS_FOUND) || defined(ROS2_FOUND)
@@ -118,8 +122,7 @@ int main(int argc, char** argv)
     RS_ERROR << "The format of config file " << config_path << " is wrong. Please check (e.g. indentation)." << RS_REND;
     return -1;
   }
-
-  std::shared_ptr<NodeManager> demo_ptr = std::make_shared<NodeManager>();
+  std::shared_ptr<NodeManager> demo_ptr = std::make_shared<NodeManager>(enable_imu_data);
   demo_ptr->init(config);
   demo_ptr->start();
 

--- a/src/manager/node_manager.cpp
+++ b/src/manager/node_manager.cpp
@@ -40,6 +40,10 @@ namespace robosense
 namespace lidar
 {
 
+NodeManager::NodeManager(bool enable):enable_imu_data(enable)
+{
+}
+
 void NodeManager::init(const YAML::Node& config)
 {
   YAML::Node common_config = yamlSubNodeAbort(config, "common");
@@ -59,6 +63,7 @@ void NodeManager::init(const YAML::Node& config)
   bool send_packet_proto;
   yamlRead<bool>(common_config, "send_packet_proto", send_packet_proto, false);
 
+  
   YAML::Node lidar_config = yamlSubNodeAbort(config, "lidar");
 
   for (uint8_t i = 0; i < lidar_config.size(); ++i)
@@ -75,7 +80,7 @@ void NodeManager::init(const YAML::Node& config)
         RS_INFO << "Difop Port: " << lidar_config[i]["driver"]["difop_port"].as<uint16_t>() << RS_REND;
         RS_INFO << "------------------------------------------------------" << RS_REND;
 
-        source = std::make_shared<SourceDriver>(SourceType::MSG_FROM_LIDAR);
+        source = std::make_shared<SourceDriver>(SourceType::MSG_FROM_LIDAR, this->enable_imu_data);
         source->init(lidar_config[i]);
         break;
 

--- a/src/manager/node_manager.hpp
+++ b/src/manager/node_manager.hpp
@@ -50,9 +50,10 @@ public:
 
   ~NodeManager();
   NodeManager() = default;
+  NodeManager(bool enable_imu_data);
 
 private:
-
+  bool enable_imu_data;
   std::vector<Source::Ptr> sources_;
 };
 

--- a/src/source/source.hpp
+++ b/src/source/source.hpp
@@ -35,7 +35,7 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "msg/rs_msg/lidar_point_cloud_msg.hpp"
 #include "utility/yaml_reader.hpp"
 #include <rs_driver/msg/packet.hpp>
-
+#include <rs_driver/msg/imu_data_msg.hpp> 
 
 namespace robosense
 {
@@ -51,9 +51,7 @@ public:
   virtual void start() {}
   virtual void stop() {}
   virtual void sendPointCloud(const LidarPointCloudMsg& msg) = 0;
-#ifdef ENABLE_IMU_DATA_PARSE
   virtual void sendImuData(const std::shared_ptr<ImuData>& msg) = 0;
-#endif
   virtual ~DestinationPointCloud() = default;
 };
 
@@ -93,9 +91,7 @@ protected:
 
   void sendPacket(const Packet& msg);
   void sendPointCloud(std::shared_ptr<LidarPointCloudMsg> msg);
-#ifdef ENABLE_IMU_DATA_PARSE
   void sendImuData(const std::shared_ptr<ImuData>& msg);
-#endif
   SourceType src_type_;
   std::vector<DestinationPointCloud::Ptr> pc_cb_vec_;
   std::vector<DestinationPacket::Ptr> pkt_cb_vec_;
@@ -132,7 +128,6 @@ inline void Source::sendPointCloud(std::shared_ptr<LidarPointCloudMsg> msg)
   }
 }
 
-#ifdef ENABLE_IMU_DATA_PARSE
 inline void Source::sendImuData(const std::shared_ptr<ImuData>& msg)
 {
   for (auto iter : pc_cb_vec_)
@@ -140,7 +135,6 @@ inline void Source::sendImuData(const std::shared_ptr<ImuData>& msg)
     iter->sendImuData(msg);
   }
 }
-#endif
 
 }  // namespace lidar
 }  // namespace robosense

--- a/src/source/source_pointcloud_ros.hpp
+++ b/src/source/source_pointcloud_ros.hpp
@@ -37,9 +37,7 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifdef ROS_FOUND
 #include <ros/ros.h>
 #include <sensor_msgs/point_cloud2_iterator.h>
-#ifdef ENABLE_IMU_DATA_PARSE
-  #include "sensor_msgs/Imu.h"
-#endif
+#include "sensor_msgs/Imu.h"
 namespace robosense
 {
 namespace lidar
@@ -179,7 +177,6 @@ inline sensor_msgs::PointCloud2 toRosMsg(const LidarPointCloudMsg& rs_msg, const
 
   return ros_msg;
 }
-#ifdef ENABLE_IMU_DATA_PARSE
 sensor_msgs::Imu toRosMsg(const std::shared_ptr<ImuData>& data, const std::string& frame_id)
 {
   sensor_msgs::Imu imu_msg;
@@ -196,7 +193,6 @@ sensor_msgs::Imu toRosMsg(const std::shared_ptr<ImuData>& data, const std::strin
   imu_msg.linear_acceleration.z = data->linear_acceleration_z;
   return imu_msg;
 }
-#endif
 class DestinationPointCloudRos : public DestinationPointCloud
 {
 public:
@@ -204,15 +200,11 @@ public:
   virtual void init(const YAML::Node& config);
   virtual void sendPointCloud(const LidarPointCloudMsg& msg);
   virtual ~DestinationPointCloudRos() = default;
-#ifdef ENABLE_IMU_DATA_PARSE
-  virtual void sendImuData(const std::shared_ptr<ImuData> & data);
-#endif
+  virtual void sendImuData(const std::shared_ptr<ImuData> & data) override;
 private:
   std::shared_ptr<ros::NodeHandle> nh_;
   ros::Publisher pub_; 
-#ifdef ENABLE_IMU_DATA_PARSE
   ros::Publisher imu_pub_; 
-#endif
   std::string frame_id_;
   bool send_by_rows_;
 };
@@ -238,24 +230,21 @@ inline void DestinationPointCloudRos::init(const YAML::Node& config)
 
   nh_ = std::unique_ptr<ros::NodeHandle>(new ros::NodeHandle());
   pub_ = nh_->advertise<sensor_msgs::PointCloud2>(ros_send_topic, 10);
-#ifdef ENABLE_IMU_DATA_PARSE
   std::string ros_send_imu_data_topic;
   yamlRead<std::string>(config["ros"], 
       "ros_send_imu_data_topic", ros_send_imu_data_topic, "rslidar_imu_data");
   imu_pub_ = nh_->advertise<sensor_msgs::Imu>(ros_send_imu_data_topic, 1000);
-#endif
 }
 
 inline void DestinationPointCloudRos::sendPointCloud(const LidarPointCloudMsg& msg)
 {
   pub_.publish(toRosMsg(msg, frame_id_, send_by_rows_));
 }
-#ifdef ENABLE_IMU_DATA_PARSE
+
 inline void DestinationPointCloudRos::sendImuData(const std::shared_ptr<ImuData> & data)
 {
   imu_pub_.publish(toRosMsg(data, frame_id_));
 }
-#endif
 }  // namespace lidar
 }  // namespace robosense
 
@@ -264,9 +253,7 @@ inline void DestinationPointCloudRos::sendImuData(const std::shared_ptr<ImuData>
 #ifdef ROS2_FOUND
 #include <rclcpp/rclcpp.hpp>
 #include <sensor_msgs/point_cloud2_iterator.hpp>
-#ifdef ENABLE_IMU_DATA_PARSE
-  #include <sensor_msgs/msg/imu.hpp>
-#endif
+#include <sensor_msgs/msg/imu.hpp>
 #include <sstream>
 
 namespace robosense
@@ -408,7 +395,6 @@ inline sensor_msgs::msg::PointCloud2 toRosMsg(const LidarPointCloudMsg& rs_msg, 
 
   return ros_msg;
 }
-#ifdef ENABLE_IMU_DATA_PARSE
 sensor_msgs::msg::Imu toRosMsg(const std::shared_ptr<ImuData>& data, const std::string& frame_id)
 {
   sensor_msgs::msg::Imu imu_msg;
@@ -425,24 +411,20 @@ sensor_msgs::msg::Imu toRosMsg(const std::shared_ptr<ImuData>& data, const std::
   imu_msg.linear_acceleration.z = data->linear_acceleration_z;
   return imu_msg;
 }
-#endif
+
 class DestinationPointCloudRos : virtual public DestinationPointCloud
 {
 public:
 
   virtual void init(const YAML::Node& config);
   virtual void sendPointCloud(const LidarPointCloudMsg& msg);
-#ifdef ENABLE_IMU_DATA_PARSE
-  virtual void sendImuData(const std::shared_ptr<ImuData> & data);
-#endif
+  virtual void sendImuData(const std::shared_ptr<ImuData> & data) override;
   virtual ~DestinationPointCloudRos() = default;
 
 private:
   std::shared_ptr<rclcpp::Node> node_ptr_;
   rclcpp::Publisher<sensor_msgs::msg::PointCloud2>::SharedPtr pub_;
-#ifdef ENABLE_IMU_DATA_PARSE
   rclcpp::Publisher<sensor_msgs::msg::Imu>::SharedPtr imu_pub_;
-#endif
   std::string frame_id_;
   bool send_by_rows_;
 };
@@ -475,12 +457,10 @@ inline void DestinationPointCloudRos::init(const YAML::Node& config)
 
   pub_ = node_ptr_->create_publisher<sensor_msgs::msg::PointCloud2>(ros_send_topic, ros_queue_length);
 
-#ifdef ENABLE_IMU_DATA_PARSE
   std::string ros_send_imu_data_topic;
   yamlRead<std::string>(config["ros"], 
       "ros_send_imu_data_topic", ros_send_imu_data_topic, "rslidar_imu_data");
   imu_pub_ = node_ptr_->create_publisher<sensor_msgs::msg::Imu>(ros_send_imu_data_topic, 1000);
-#endif
 
 }
 
@@ -488,12 +468,11 @@ inline void DestinationPointCloudRos::sendPointCloud(const LidarPointCloudMsg& m
 {
   pub_->publish(toRosMsg(msg, frame_id_, send_by_rows_));
 }
-#ifdef ENABLE_IMU_DATA_PARSE
+
 inline void DestinationPointCloudRos::sendImuData(const std::shared_ptr<ImuData> & data)
 {
   imu_pub_->publish(toRosMsg(data, frame_id_));
 }
-#endif
 }  // namespace lidar
 }  // namespace robosense
 


### PR DESCRIPTION
# 1 Purpose

1. Remove the `ENABLE_IMU_DATA_PARSE` option in CmakeLists.
2. add `enable_imu_data:=true` command in ROS start scripts.

So you only need to build it once, and then dynamically control IMU_data by specifying the `enable_imu_data` option of the startup scripts.

---

# 2 How to use
1. ROS1: `roslaunch rslidar_sdk start.launch enable_data_imu:=true`
2. ROS2: `ros2 launch rslidar_sdk start.py enable_data_imu:=true`
3. humble: `ros2 launch rslidar_sdk humble_start.py enable_imu_data:=true`
4. eloquent: `ros2 launch rslidar_sdk elequent_start.py enable_imu_data:=true`

> when you don't use this option explicitly, the default value is false.

---

# 3 How to achieve this feature

1. Remove all static compilation instructions related to `ENABLE-IMUDATA-PARSE`
2. Refer to the startup script code and define a parameter variable `enable_imu_data` in the ROS node
3. At startup, `rslidar_sdk_node. cpp` reads the parameter values from the ROS node and passes them to the `NodeManager `instance. When the `NodeManager` instance initializes (Function `NodeManager:: init `), it passes them to the `SourceDriver` instance and stores the value of ` enable_imu_data` in a private member variable, which controls whether IMU related functions are started or not

> The transmission process of `enable_imu_data` value: `ROS node` -> `rslidar_sdk_node.cpp` ->`NodeManager` ->  `SourceDriver` 