### PR TITLE
Allow specifying POINT_TYPE as cmake option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,9 @@ project(rslidar_sdk)
 #=======================================
 # Custom Point Type (XYZI,XYZIRT, XYZIF, XYZIRTF)
 #=======================================
-set(POINT_TYPE XYZI)
+if(NOT POINT_TYPE)
+  set(POINT_TYPE XYZI)
+endif()
 
 option(ENABLE_TRANSFORM "Enable transform functions" OFF)
 if(${ENABLE_TRANSFORM})

--- a/doc/howto/05_how_to_change_point_type.md
+++ b/doc/howto/05_how_to_change_point_type.md
@@ -6,13 +6,25 @@
 
 This document illustrates how to change the point type. 
 
-In ```CMakeLists.txt``` of the project, change the variable `POINT_TYPE`. Remember to **rebuild** the project after changing it.
+In `CMakeLists.txt` of the project, the point type is defined using the `POINT_TYPE` variable.
 
 ```cmake
 #=======================================
 # Custom Point Type (XYZI,XYZIRT, XYZIF, XYZIRTF)
 #=======================================
-set(POINT_TYPE XYZI)
+if(NOT POINT_TYPE)
+  set(POINT_TYPE XYZI)
+endif()
+```
+
+You can edit this file to replace the default value `XYZI` by the desired one.
+Remember to **rebuild** the project after changing it.
+
+It is also possible to specify it from the command line by specifying it as a cmake option.
+For example, in ROS2, to use `XYZIRTF`, the colcon command is:
+
+```
+colcon build --packages-select rslidar_sdk --cmake-args -DPOINT_TYPE=XYZIRTF
 ```
 
 


### PR DESCRIPTION
Currently, in the `CMakeLists.txt`, the `POINT_TYPE` is defined using
```cmake
#=======================================
# Custom Point Type (XYZI,XYZIRT, XYZIF, XYZIRTF)
#=======================================
set(POINT_TYPE XYZI)
```

As explained in the documentation, to change its value, the user have to edit this file.
I believe that users should not have to edit any project file just to choose a particular configuration. This would requires them to create a fork of the project to maintain their changes.

Instead, I propose to let the user select the `POINT_TYPE` in a similar way than other options like `ENABLE_DIFOP_PARSE` or `ENABLE_IMU_DATA_PARSE`. It is still possible to edit the CMakeLists.txt, but this PR allows to specify the `POINT_TYPE` from the command line. For example, in ROS2 with colcon:
```
colcon build --packages-select rslidar_sdk --cmake-args -DPOINT_TYPE=XYZIRTF
```

To summarize, I changed the following things:
* I have added a condition to check if `POINT_TYPE` is already defined in the `CMakeLists.txt`
* I have updated the documentation to explain the different way to set its value

However, I do not speak Chinese, so I do not have edited this version of the documentation.