### PR TITLE
Fix deprecation of ament_target_dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -188,11 +188,11 @@ endif(roscpp_FOUND)
 #Ros2#
 if(rclcpp_FOUND)
 
-  ament_target_dependencies(rslidar_sdk_node 
-    rclcpp 
-    std_msgs 
-    sensor_msgs 
-    rslidar_msg)
+  target_link_libraries(rslidar_sdk_node
+    ${rslidar_msg_TARGETS}
+    ${sensor_msgs_TARGETS}
+    ${std_msgs_TARGETS}
+    rclcpp::rclcpp)
 
   install(TARGETS
     rslidar_sdk_node


### PR DESCRIPTION
Required for rolling and kilted.
Fully backwards compatible.

Pinging @FelixHuang18 as last member that merged anything in this repo.