### PR TITLE
Phenotyping workspace: public rs_driver URL + RSHELIOS config

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "src/rs_driver"]
 	path = src/rs_driver
-	url = ../rs_driver.git
+	url = https://github.com/RoboSense-LiDAR/rs_driver.git

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -7,11 +7,11 @@ common:
   send_point_cloud_ros: true            # true: Send point cloud through ROS or ROS2
 lidar:
   - driver:
-      lidar_type: RSM1             #  LiDAR type - RS16, RS32, RSBP, RSAIRY, RSFAIRY, RSHELIOS, RSHELIOS_16P, RS128, RS80, RS48, RSP128, RSP80, RSP48, 
-                                   #               RSM1, RSM1_JUMBO, RSM2, RSM3, RSE1, RSMX, RSEMX.
+      lidar_type: RSHELIOS             #  LiDAR type - RS16, RS32, RSBP, RSAIRY, RSHELIOS, RSHELIOS_16P, RS128, RS80, RS48, RSP128, RSP80, RSP48, 
+                                   #               RSM1, RSM1_JUMBO, RSM2, RSM3, RSE1, RSMX.
                                    
       msop_port: 6699              #  Msop port of lidar
-      difop_port: 7788             #  Difop port of lidar (Note that: For RSEMX, use the port num of DIFOP2 if both DIFOP1 & DIFOP2 exist. Default 7766.)
+      difop_port: 7788             #  Difop port of lidar
       imu_port: 0                  #  IMU port of lidar(only for RSAIRY, RSE1), 0 means no imu.
                                    #  If you want to use IMU, please first set ENABLE_IMU_DATA_PARSE to ON in CMakeLists.txt 
       user_layer_bytes: 0          #  Bytes of user layer. thers is no user layer if it is 0         
@@ -19,7 +19,7 @@ lidar:
 
 
       min_distance: 0.2            #  Minimum distance of point cloud
-      max_distance: 200            #  Maximum distance of point cloud (Note that: 200 normally, 300 for RSEMX)
+      max_distance: 200            #  Maximum distance of point cloud
       use_lidar_clock: true        #  true--Use the lidar clock as the message timestamp
                                    #  false-- Use the system clock as the timestamp
       dense_points: false          #  true: discard NAN points; false: reserve NAN points


### PR DESCRIPTION
- Point src/rs_driver submodule at GitHub HTTPS so clones work outside RoboSense monorepo layout
- Set lidar_type to RSHELIOS for current hardware

Made-with: Cursor