### PR TITLE
Set point type using cmake args

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "src/rs_driver"]
 	path = src/rs_driver
-	url = ../rs_driver.git
+	url = https://github.com/RoboSense-LiDAR/rs_driver.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,8 @@ project(rslidar_sdk)
 #=======================================
 # Custom Point Type (XYZI,XYZIRT, XYZIF, XYZIRTF)
 #=======================================
-set(POINT_TYPE XYZI)
+set(POINT_TYPE "XYZI" CACHE STRING "Custom Point Type")
+set_property(CACHE POINT_TYPE PROPERTY STRINGS XYZI XYZIRT XYZIF XYZIRTF)
 
 option(ENABLE_TRANSFORM "Enable transform functions" OFF)
 if(${ENABLE_TRANSFORM})
@@ -74,13 +75,13 @@ add_compile_options(-Wall)
 #========================
 # Point Type Definition
 #========================
-if(${POINT_TYPE} STREQUAL "XYZI")
+if(POINT_TYPE STREQUAL "XYZI")
   add_definitions(-DPOINT_TYPE_XYZI)
-elseif(${POINT_TYPE} STREQUAL "XYZIRT")
+elseif(POINT_TYPE STREQUAL "XYZIRT")
   add_definitions(-DPOINT_TYPE_XYZIRT)
-elseif(${POINT_TYPE} STREQUAL "XYZIF")
+elseif(POINT_TYPE STREQUAL "XYZIF")
   add_definitions(-DPOINT_TYPE_XYZIF)
-elseif(${POINT_TYPE} STREQUAL "XYZIRTF")
+elseif(POINT_TYPE STREQUAL "XYZIRTF")
   add_definitions(-DPOINT_TYPE_XYZIRTF)
 endif()
 


### PR DESCRIPTION
The CMakeLists.txt does not provide the option to set point_type via cmake-args. This will require editing it each time when a new point type needs to be used. These changes let the user to pass the argument `-DPOINT_TYPE=YOUR_PREFERRED_POINT-TYPE` using cmake-args (XYZI XYZIRT XYZIF XYZIRTF)